### PR TITLE
Add job name to CI workflow for branch protection status check

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    name: build # name to trigger in github branch ruleset
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
This PR adds a name (`build`) to the job in the GitHub Actions workflow (Python CI/CD) so that it appears as a selectable status check in the branch protection rule settings.

- Added `name: build` under the `jobs.build` section.
- This change allows GitHub to display the status check as `Python CI/CD / build` in protection rules.
- No logic or build step has been modified.

Once this PR runs successfully, we can go to:
Settings → Branches → Protection Rule → Require status checks → Add check → Select `Python CI/CD / build`
